### PR TITLE
Fixed triggering of menu actions

### DIFF
--- a/src/dbusmenuimporter.cpp
+++ b/src/dbusmenuimporter.cpp
@@ -339,7 +339,7 @@ DBusMenuImporter::DBusMenuImporter(const QString &service, const QString &path, 
 
     d->m_type = type;
 
-    connect(&d->m_mapper, SIGNAL(mapped(int)), SLOT(sendClickedEvent(int)));
+    connect(&d->m_mapper, SIGNAL(mappedInt(int)), SLOT(sendClickedEvent(int)));
 
     d->m_pendingLayoutUpdateTimer = new QTimer(this);
     d->m_pendingLayoutUpdateTimer->setSingleShot(true);


### PR DESCRIPTION
`QSignalMapper::map` was removed from Qt5 but still worked there, while it doesn't work in Qt6. `QSignalMapper::mappedInt` should be used instead.

Strange that Qt6 doesn't even warn against using it!

Fixes https://github.com/lxqt/libdbusmenu-lxqt/issues/9