### PR TITLE
Workaround for a Qt crash on reloading menus

### DIFF
--- a/src/dbusmenuimporter.h
+++ b/src/dbusmenuimporter.h
@@ -23,6 +23,7 @@
 
 // Qt
 #include <QtCore/QObject>
+#include <QMenu>
 
 // Local
 #include <dbusmenu_export.h>
@@ -32,9 +33,20 @@ class QDBusAbstractInterface;
 class QDBusPendingCallWatcher;
 class QDBusVariant;
 class QIcon;
-class QMenu;
+class QEvent;
 
 class DBusMenuImporterPrivate;
+
+// For working around a crash triggered by "QMenu::timerEvent"
+class Menu : public QMenu {
+    Q_OBJECT
+public:
+    Menu(QWidget *parent = nullptr);
+    bool blockEvents;
+
+protected:
+    bool event(QEvent *e) override;
+};
 
 /**
  * Determine whether internal method calls should allow the Qt event loop


### PR DESCRIPTION
Such random crashes are triggered by Qt → `QMenu::timerEvent()`. Qt doesn't take into account the possibility of dangling pointers in `qmenu.cpp` under very rare circumstances, e.g., when the actions of a menu with a visible submenu are recreated too rapidly multiple times (also see https://bugreports.qt.io/browse/QTBUG-77273, although our case is much more complex). That may no be unexpected in a code full of timers and event handling.

To avoid dangling pointers, the patch just puts a minimum interval of two seconds between two consecutive reloads.

It also restores the active action on refreshing, such that a reloaded submenu isn't closed anymore (see https://github.com/lxqt/lxqt/issues/2282 and especially @yan12125's report https://gitlab.gnome.org/GNOME/network-manager-applet/-/issues/195).

Finally, it removes a redundant, recursive computation.

Closes https://github.com/lxqt/lxqt-panel/issues/1802

NOTE: I was able to reproduce the crash easily with nm-applet. Before arriving at this workaround, I tried various ideas but could still make lxqt-panel crash in a few minutes. Only this time I can't, in spite of trying for days.