### PR TITLE
exporter: Allow to set parent to exporter

### DIFF
--- a/src/dbusmenu_p.cpp
+++ b/src/dbusmenu_p.cpp
@@ -31,7 +31,7 @@
 #include "debug_p.h"
 
 DBusMenu::DBusMenu(QMenu *menu, DBusMenuExporter *exporter, int parentId)
-: QObject(menu)
+: QObject(exporter)
 , m_exporter(exporter)
 , m_parentId(parentId)
 {

--- a/src/dbusmenuexporter.cpp
+++ b/src/dbusmenuexporter.cpp
@@ -55,11 +55,6 @@ int DBusMenuExporterPrivate::idForAction(QAction *action) const
 
 void DBusMenuExporterPrivate::addMenu(QMenu *menu, int parentId)
 {
-    if (menu->findChild<DBusMenu *>()) {
-        // This can happen if a menu is removed from its parent and added back
-        // See KDE bug 254066
-        return;
-    }
     new DBusMenu(menu, q, parentId);
     const auto mActions = menu->actions();
     for (QAction *action : mActions) {
@@ -328,8 +323,8 @@ void DBusMenuExporterPrivate::collapseSeparators(QMenu* menu)
 // DBusMenuExporter
 //
 //-------------------------------------------------
-DBusMenuExporter::DBusMenuExporter(const QString &objectPath, QMenu *menu, const QDBusConnection &_connection)
-: QObject(menu)
+DBusMenuExporter::DBusMenuExporter(const QString &objectPath, QMenu *menu, QObject *parent, const QDBusConnection &_connection)
+: QObject(parent)
 , d(new DBusMenuExporterPrivate)
 {
     d->q = this;
@@ -355,6 +350,10 @@ DBusMenuExporter::DBusMenuExporter(const QString &objectPath, QMenu *menu, const
     QDBusConnection connection(_connection);
     connection.registerObject(objectPath, d->m_dbusObject, QDBusConnection::ExportAllContents);
 }
+
+DBusMenuExporter::DBusMenuExporter(const QString &dbusObjectPath, QMenu *menu, const QDBusConnection &dbusConnection/* = QDBusConnection::sessionBus()*/)
+: DBusMenuExporter(dbusObjectPath, menu, menu, dbusConnection)
+{}
 
 DBusMenuExporter::~DBusMenuExporter()
 {

--- a/src/dbusmenuexporter.h
+++ b/src/dbusmenuexporter.h
@@ -24,12 +24,12 @@
 // Qt
 #include <QtCore/QObject>
 #include <QtDBus/QDBusConnection>
+#include <QMenu>
 
 // Local
 #include <dbusmenu_export.h>
 
 class QAction;
-class QMenu;
 
 class DBusMenuExporterPrivate;
 
@@ -43,6 +43,9 @@ public:
     /**
      * Creates a DBusMenuExporter exporting menu at the dbus object path
      * dbusObjectPath, using the given dbusConnection.
+     */
+    DBusMenuExporter(const QString &dbusObjectPath, QMenu *menu, QObject *parent, const QDBusConnection &dbusConnection = QDBusConnection::sessionBus());
+    /**
      * The instance adds itself to the menu children.
      */
     DBusMenuExporter(const QString &dbusObjectPath, QMenu *menu, const QDBusConnection &dbusConnection = QDBusConnection::sessionBus());


### PR DESCRIPTION
1. the exported QMenu doesn't need to be dedicated to only DBusMenuExporter => don't force the menu be parent of the exporter
2. in case menu can be shown by multiple DBusMenuExporters we need to populate the "exported" menu items for each exporter