### PR TITLE
Silence warning

### DIFF
--- a/src/dbusmenuimporter.cpp
+++ b/src/dbusmenuimporter.cpp
@@ -403,7 +403,7 @@ DBusMenuImporter::~DBusMenuImporter()
     delete d;
 }
 
-void DBusMenuImporter::slotLayoutUpdated(uint revision, int parentId)
+void DBusMenuImporter::slotLayoutUpdated(uint /*revision*/, int parentId)
 {
     if (d->m_idsRefreshedByAboutToShow.remove(parentId)) {
         return;


### PR DESCRIPTION
There was one warning with GCC `-Wall -Wextra -Wpedantic`. Surprisingly warnings are rare for LXQt when compiled with those flags. I am aware of the `com.canonical.dbusmenu.xml` warnings but it looks too complicated. There may be more warnings with Clang.