### PR TITLE
Replace old style SIGNAL/SLOT

### DIFF
--- a/src/dbusmenu_p.cpp
+++ b/src/dbusmenu_p.cpp
@@ -36,7 +36,7 @@ DBusMenu::DBusMenu(QMenu *menu, DBusMenuExporter *exporter, int parentId)
 , m_parentId(parentId)
 {
     menu->installEventFilter(this);
-    connect(m_exporter, SIGNAL(destroyed(QObject*)), SLOT(deleteMe()));
+    connect(m_exporter, &DBusMenuExporter::destroyed, this, &DBusMenu::deleteMe);
 }
 
 DBusMenu::~DBusMenu()

--- a/src/dbusmenuexporter.cpp
+++ b/src/dbusmenuexporter.cpp
@@ -195,7 +195,7 @@ void DBusMenuExporterPrivate::addAction(QAction *action, int parentId)
     }
     QVariantMap map = propertiesForAction(action);
     id = m_nextId++;
-    QObject::connect(action, SIGNAL(destroyed(QObject*)), q, SLOT(slotActionDestroyed(QObject*)));
+    QObject::connect(action, &QAction::destroyed, q, &DBusMenuExporter::slotActionDestroyed);
     m_actionForId.insert(id, action);
     m_idForAction.insert(action, id);
     m_actionProperties.insert(action, map);
@@ -222,7 +222,7 @@ void DBusMenuExporterPrivate::removeActionInternal(QObject *object)
 void DBusMenuExporterPrivate::removeAction(QAction *action, int parentId)
 {
     removeActionInternal(action);
-    QObject::disconnect(action, SIGNAL(destroyed(QObject*)), q, SLOT(slotActionDestroyed(QObject*)));
+    QObject::disconnect(action, &QAction::destroyed, q, &DBusMenuExporter::slotActionDestroyed);
     ++m_revision;
     emitLayoutUpdated(parentId);
 }
@@ -349,11 +349,11 @@ DBusMenuExporter::DBusMenuExporter(const QString &objectPath, QMenu *menu, const
 
     d->m_itemUpdatedTimer->setInterval(0);
     d->m_itemUpdatedTimer->setSingleShot(true);
-    connect(d->m_itemUpdatedTimer, SIGNAL(timeout()), SLOT(doUpdateActions()));
+    connect(d->m_itemUpdatedTimer, &QTimer::timeout, this, &DBusMenuExporter::doUpdateActions);
 
     d->m_layoutUpdatedTimer->setInterval(0);
     d->m_layoutUpdatedTimer->setSingleShot(true);
-    connect(d->m_layoutUpdatedTimer, SIGNAL(timeout()), SLOT(doEmitLayoutUpdated()));
+    connect(d->m_layoutUpdatedTimer, &QTimer::timeout, this, &DBusMenuExporter::doEmitLayoutUpdated);
 
     QDBusConnection connection(_connection);
     connection.registerObject(objectPath, d->m_dbusObject, QDBusConnection::ExportAllContents);

--- a/src/dbusmenuimporter.cpp
+++ b/src/dbusmenuimporter.cpp
@@ -128,8 +128,7 @@ public:
         QDBusPendingCall call = m_interface->asyncCall("GetLayout"_L1, id, 1, QStringList());
         QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, q);
         watcher->setProperty(DBUSMENU_PROPERTY_ID, id);
-        QObject::connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
-            q, SLOT(slotGetLayoutFinished(QDBusPendingCallWatcher*)));
+        QObject::connect(watcher, &QDBusPendingCallWatcher::finished, q, &DBusMenuImporter::slotGetLayoutFinished);
 
         return watcher;
     }
@@ -137,10 +136,8 @@ public:
     QMenu *createMenu(QWidget *parent)
     {
         QMenu *menu = q->createMenu(parent);
-        QObject::connect(menu, SIGNAL(aboutToShow()),
-            q, SLOT(slotMenuAboutToShow()));
-        QObject::connect(menu, SIGNAL(aboutToHide()),
-            q, SLOT(slotMenuAboutToHide()));
+        QObject::connect(menu, &QMenu::aboutToShow, q, &DBusMenuImporter::slotMenuAboutToShow);
+        QObject::connect(menu, &QMenu::aboutToHide, q, &DBusMenuImporter::slotMenuAboutToHide);
         return menu;
     }
 
@@ -318,8 +315,8 @@ public:
             QTimer timer;
             timer.setSingleShot(true);
             QEventLoop loop;
-            loop.connect(&timer, SIGNAL(timeout()), SLOT(quit()));
-            loop.connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher *)), SLOT(quit()));
+            loop.connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
+            loop.connect(watcher, &QDBusPendingCallWatcher::finished, &loop, &QEventLoop::quit);
             timer.start(maxWait);
             loop.exec();
             timer.stop();
@@ -367,7 +364,7 @@ DBusMenuImporter::DBusMenuImporter(const QString &service, const QString &path, 
 
     d->m_type = type;
 
-    connect(&d->m_mapper, SIGNAL(mappedInt(int)), SLOT(sendClickedEvent(int)));
+    connect(&d->m_mapper, &QSignalMapper::mappedInt, this, &DBusMenuImporter::sendClickedEvent);
 
     d->m_pendingLayoutUpdateTimer = new QTimer(this);
     d->m_pendingLayoutUpdateTimer->setSingleShot(true);
@@ -383,7 +380,7 @@ DBusMenuImporter::DBusMenuImporter(const QString &service, const QString &path, 
      * events during updates, especially the timer events.
      */
     d->m_pendingLayoutUpdateTimer->setInterval(LAYOUT_UPDATE_TIMEOUT);
-    connect(d->m_pendingLayoutUpdateTimer, SIGNAL(timeout()), SLOT(processPendingLayoutUpdates()));
+    connect(d->m_pendingLayoutUpdateTimer, &QTimer::timeout, this, &DBusMenuImporter::processPendingLayoutUpdates);
 
     // For some reason, using QObject::connect() does not work but
     // QDBusConnect::connect() does
@@ -523,8 +520,7 @@ void DBusMenuImporter::slotGetLayoutFinished(QDBusPendingCallWatcher *watcher)
         }
         menu->addAction(action);
 
-        connect(action, SIGNAL(triggered()),
-            &d->m_mapper, SLOT(map()));
+        connect(action, &QAction::triggered, &d->m_mapper, qOverload<>(&QSignalMapper::map));
         d->m_mapper.setMapping(action, dbusMenuItem.id);
 
         if (index == activeIndex) {
@@ -600,8 +596,7 @@ void DBusMenuImporter::slotMenuAboutToShow()
     QDBusPendingCall call = d->m_interface->asyncCall("AboutToShow"_L1, id);
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
     watcher->setProperty(DBUSMENU_PROPERTY_ID, id);
-    connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
-        SLOT(slotAboutToShowDBusCallFinished(QDBusPendingCallWatcher*)));
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, &DBusMenuImporter::slotAboutToShowDBusCallFinished);
 
     QPointer<QObject> guard(this);
 

--- a/tests/dbusmenuexportertest.cpp
+++ b/tests/dbusmenuexportertest.cpp
@@ -203,7 +203,7 @@ void DBusMenuExporterTest::testClickedEvent()
 {
     QMenu inputMenu;
     QAction *action = inputMenu.addAction("a1"_L1);
-    QSignalSpy spy(action, SIGNAL(triggered()));
+    QSignalSpy spy(action, &QAction::triggered);
     DBusMenuExporter exporter(TEST_OBJECT_PATH, &inputMenu);
 
     QDBusInterface iface(TEST_SERVICE, TEST_OBJECT_PATH);

--- a/tests/dbusmenuimportertest.cpp
+++ b/tests/dbusmenuimportertest.cpp
@@ -117,7 +117,7 @@ void DBusMenuImporterTest::testDeletingImporterWhileWaitingForAboutToShow()
     QTest::qWait(500);
 
     QMenu *outputMenu = importer->menu();
-    QTimer::singleShot(100, importer, SLOT(deleteLater()));
+    QTimer::singleShot(100, importer, &DBusMenuImporter::deleteLater);
     outputMenu->popup(QPoint(0, 0));
 
     // If it crashes, it will crash while waiting there
@@ -154,8 +154,8 @@ void DBusMenuImporterTest::testDynamicMenu()
     QCOMPARE(outputMenu->actions().count(), 0);
 
     // Update menu, a1 and a2 should get added
-    QSignalSpy spy(&importer, SIGNAL(menuUpdated()));
-    QSignalSpy spyOld(&importer, SIGNAL(menuReadyToBeShown()));
+    QSignalSpy spy(&importer, &DBusMenuImporter::menuUpdated);
+    QSignalSpy spyOld(&importer, &DBusMenuImporter::menuReadyToBeShown);
     importer.updateMenu();
     while (spy.isEmpty()) {
         QTest::qWait(500);
@@ -192,7 +192,7 @@ void DBusMenuImporterTest::testActionActivationRequested()
 
     // Import the menu
     DBusMenuImporter importer(TEST_SERVICE, TEST_OBJECT_PATH);
-    QSignalSpy spy(&importer, SIGNAL(actionActivationRequested(QAction*)));
+    QSignalSpy spy(&importer, &DBusMenuImporter::actionActivationRequested);
 
     QTest::qWait(500);
     QMenu *outputMenu = importer.menu();

--- a/tests/slowmenu.cpp
+++ b/tests/slowmenu.cpp
@@ -35,7 +35,7 @@ static const char *TEST_OBJECT_PATH = "/TestMenuBar";
 SlowMenu::SlowMenu()
 : QMenu()
 {
-    connect(this, SIGNAL(aboutToShow()), SLOT(slotAboutToShow()));
+    connect(this, &SlowMenu::aboutToShow, this, &SlowMenu::slotAboutToShow);
 }
 
 void SlowMenu::slotAboutToShow()

--- a/tests/testutils.h
+++ b/tests/testutils.h
@@ -83,7 +83,7 @@ public:
     MenuFiller(QMenu *menu)
     : m_menu(menu)
     {
-        connect(m_menu, SIGNAL(aboutToShow()), SLOT(fillMenu()));
+        connect(m_menu, &QMenu::aboutToShow, this, &MenuFiller::fillMenu);
     }
 
     void addAction(QAction *action)


### PR DESCRIPTION
Replace connect `SIGNAL(...)`/`SLOT(...)` wherever possible.

It needs a good double-check although it compiles.