### PR TITLE
cmake: fix libdir path and tweak whitespacing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,12 @@ include (CheckCXXCompilerFlag)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
-set(LIB_DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-set(CMAKECONFIG_INSTALL_DIR "${LIB_DESTINATION}/cmake/dbusmenu-lxqt")
-set(INCLUDE_INSTALL_DIR "include/dbusmenu-lxqt")
+set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/dbusmenu-lxqt")
 
 configure_file(dbusmenu-lxqt.pc.in ${CMAKE_BINARY_DIR}/dbusmenu-lxqt.pc @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/dbusmenu-lxqt.pc
-        DESTINATION ${LIB_DESTINATION}/pkgconfig
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
 add_subdirectory(src)
@@ -51,7 +49,7 @@ add_subdirectory(tests)
 configure_package_config_file(
     dbusmenu-lxqt-config.cmake.in
     ${CMAKE_BINARY_DIR}/dbusmenu-lxqt-config.cmake
-    INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR}
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/dbusmenu-lxqt
     PATH_VARS INCLUDE_INSTALL_DIR
 )
 
@@ -65,6 +63,6 @@ write_basic_package_version_file(
 install(FILES
     ${CMAKE_BINARY_DIR}/dbusmenu-lxqt-config.cmake
     ${CMAKE_BINARY_DIR}/dbusmenu-lxqt-config-version.cmake
-    DESTINATION "${CMAKECONFIG_INSTALL_DIR}"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/dbusmenu-lxqt"
     COMPONENT Devel
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ find_package(Qt6 ${QT_MINIMUM_VERSION} REQUIRED COMPONENTS Core Widgets DBus)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-include (LXQtCompilerSettings NO_POLICY_SCOPE)
-include (CheckCXXCompilerFlag)
+include(LXQtCompilerSettings NO_POLICY_SCOPE)
+include(CheckCXXCompilerFlag)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 

--- a/dbusmenu-lxqt.pc.in
+++ b/dbusmenu-lxqt.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/lib
-includedir=@CMAKE_INSTALL_PREFIX@/include/dbusmenu-lxqt
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/dbusmenu-lxqt
 
 Name: libdbusmenu-lxqt
 Description: Qt implementation of dbusmenu spec

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,23 +30,23 @@ target_link_libraries(dbusmenu-lxqt
 
 # Make sure linking to the target adds dbusmenu-lxqt install directory
 target_include_directories(dbusmenu-lxqt
-    INTERFACE "$<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>")
+    INTERFACE "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/dbusmenu-lxqt>")
 
 install(TARGETS dbusmenu-lxqt
     EXPORT dbusmenu-lxqt-targets
-    LIBRARY DESTINATION ${LIB_DESTINATION}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION bin
 )
 
 install(EXPORT dbusmenu-lxqt-targets
-    DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/dbusmenu-lxqt)
 
 install(DIRECTORY .
-    DESTINATION ${INCLUDE_INSTALL_DIR}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dbusmenu-lxqt
     FILES_MATCHING PATTERN "*.h"
     PATTERN "*_p.h" EXCLUDE
 )
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dbusmenu_version.h
-    DESTINATION ${INCLUDE_INSTALL_DIR}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dbusmenu-lxqt
 )


### PR DESCRIPTION
Been carrying this on Gentoo Linux (previously also used for the now-removed 'libdbusmenu-qt' as well from which this is adapted from), and been meaning to offer it but never remembered to get to it... until now.

Also noticed a couple of whitespaces that poke out from all the rest.
